### PR TITLE
Reset websocket after trying to emit to a non-existing room

### DIFF
--- a/src/Websocket/Websocket.php
+++ b/src/Websocket/Websocket.php
@@ -170,6 +170,7 @@ class Websocket
         // that means trying to emit to a non-existing room
         // skip it directly instead of pushing to a task queue
         if (empty($fds) && $assigned) {
+            $this->reset();
             return false;
         }
 


### PR DESCRIPTION
If I am trying to emit an event to a non-existing room, the emit function skips the task, but does not reset the data. Therefore, if I am unaware of the room not existing and later try to send a reply to the current connection (without setting the to param), it will still be treated as if I am trying to emit to the previous room and will seem like the connection is dead as no message is thrown.